### PR TITLE
Raw approx bug

### DIFF
--- a/reals.lisp
+++ b/reals.lisp
@@ -150,8 +150,9 @@ denoting the number of binary digits after the decimal point")
   (do* ((k 0 (+ k 4))
         (a (get-approx x 0) (get-approx x k))
         (crt (+ 2 *creal-tolerance*)))
-       ((> (abs a) 4) (values (abs a) k (signum a)))
-    (when (> k crt) (return (values 0 (- k 3) 0)))))
+       ((or (> (abs a) 4)
+            (> k crt))
+        (values (abs a) k (signum a)))))
 
 (defun RAW-APPROX-R (x)
   "Returns an approximation for CREALs"

--- a/realstst.lisp
+++ b/realstst.lisp
@@ -1,21 +1,28 @@
-(load "reals.lsp")
-(echo t)
-(use-package "REALS")
-(print-r pi-r 20)
+;;;; realstst.lisp
+
+;;;; Tests for Reals
+
+(in-package #:cr)
+
+(print-r +pi-r+ 20)
 (print-r (sqrt-r 2) 20)
-(print-r pi-r 50)
-(print-r (setq e163 (exp-r (*r pi-r (sqrt-r 163)))) 20)
-(print-r (setq e58 (exp-r (*r pi-r (sqrt-r 58)))) 20)
+(print-r +pi-r+ 50)
+
+(defvar e163 (exp-r (*r +pi-r+ (sqrt-r 163))))
+(print-r e163 20)
+
+(defvar e58 (exp-r (*r +pi-r+ (sqrt-r 58))))
+(print-r e58 20)
+
 (defun get-koeffs (x n &aux (y x) q r)
   (dotimes (i n)
     (multiple-value-setq (q r) (round-r y))
     (print q)
-    (setq y (*r x r))
-) )
+    (setq y (*r x r))))
+
 (get-koeffs e163 10)
 (get-koeffs e58 10)
-(print-r (sin-r pi-r) 20)
-(print-r (cos-r pi-r) 20)
-(print-r (sin-r pi/2-r) 20)
-(echo nil)
+(print-r (sin-r +pi-r+) 20)
+(print-r (cos-r +pi-r+) 20)
+(print-r (sin-r +pi/2-r+) 20)
 


### PR DESCRIPTION
This fixes a zero-looping bug in `raw-approx-cr`.
 
`raw-approx-cr` is supposed find a minimal approximation for use in arithmetic functions. It does this by adding precision until the absolute-value of the approximation is greater 4. Unfortunately, for zero, it had no threshold to stop making approximations with increasing precision, causing it to loop infinitely. 

Even with the fix, approximation and comparison are inherently inexact with computable-reals, which means that `raw-approx-cr` and other functions have behavior that should be addressed. I'll make a separate issue for it. 